### PR TITLE
Fix SolanaRPC: allow to process scalar result data

### DIFF
--- a/src/SolanaRPC.php
+++ b/src/SolanaRPC.php
@@ -41,7 +41,7 @@ class SolanaRPC {
                 throw new \Exception("RPC Error: " . $data['error']['message']);
             }
 
-            return $data['result'];
+            return \is_scalar($data['result']) ? $data : $data['result'];
         } catch (RequestException $e) {
             throw new \Exception("HTTP Request Error: " . $e->getMessage());
         }


### PR DESCRIPTION
Some requests return not array result. For example request to airdrop